### PR TITLE
Fix serialize call more than once :(

### DIFF
--- a/lib/active_record_encrypted_string/type.rb
+++ b/lib/active_record_encrypted_string/type.rb
@@ -36,6 +36,10 @@ module ActiveRecordEncryptedString
       v.present? ? encryptor.decrypt_and_verify(v) : v
     end
 
+    def changed_in_place?(raw_old_value, new_value)
+      deserialize(raw_old_value) != new_value
+    end
+
     private
 
     def encryptor

--- a/spec/active_record_encrypted_string_spec.rb
+++ b/spec/active_record_encrypted_string_spec.rb
@@ -121,6 +121,22 @@ RSpec.describe ActiveRecordEncryptedString do
     let(:instance) { dummy_klass.new(plain: plain, encrypted: value) }
     let(:plain) { 'plain' }
 
+    context 'no changes encryption' do
+      let(:value) { :encrypted }
+      let(:dummy_klass) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = 'dummys'
+
+          attribute :encrypted, :encrypted_string
+        end
+      end
+
+      it 'should not update encrypted when not changed' do
+        instance.save!
+        expect { instance.save! }.not_to change { instance.read_attribute_before_type_cast(:encrypted) } # rubocop:disable Lint/AmbiguousBlockAssociation
+      end
+    end
+
     context 'encrypt with default salt' do
       let(:dummy_klass) do
         Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
Hello,

Somehow, rails seems to call `serialize` at least twice when loading from the database and saving right after even without any changes.

I figured that out while testing in our app and a rails console. I was wondering why my encrypted columns were updated as many times as save! was called. Anyway, I added a spec that makes sure that the raw_value hasn't change within that case.
