### PR TITLE
Missing change_in_place? in type

### DIFF
--- a/lib/active_record_encrypted_string/type.rb
+++ b/lib/active_record_encrypted_string/type.rb
@@ -28,6 +28,10 @@ module ActiveRecordEncryptedString
       v.present? ? encryptor.decrypt_and_verify(v) : v
     end
 
+    def changed_in_place?(raw_old_value, new_value)
+      deserialize(raw_old_value) != new_value if new_value.is_a?(::String)
+    end
+
     private
 
     def encryptor

--- a/spec/active_record_encrypted_string_spec.rb
+++ b/spec/active_record_encrypted_string_spec.rb
@@ -117,6 +117,10 @@ RSpec.describe ActiveRecordEncryptedString do
       end
     end
 
+    after :all do
+      ActiveRecord::Base.connection.drop_table('dummys')
+    end
+
     subject { instance.save! }
     let(:instance) { dummy_klass.new(plain: plain, encrypted: value) }
     let(:plain) { 'plain' }
@@ -145,6 +149,48 @@ RSpec.describe ActiveRecordEncryptedString do
 
       it_behaves_like 'pass null or empty string to encrypted'
       it_behaves_like 'pass existing values to encrypted'
+    end
+  end
+
+  describe 'changed_in_place' do
+    before(:all) do
+      ActiveRecord::Base.connection.create_table('dummys') do |t|
+        t.string :encrypted
+      end
+
+      ActiveRecordEncryptedString.configure do |c|
+        c.secret_key = '5b13d146feab83d630313732178c2b782e9eb54f3db492b24b2afc084a6e6cc38aa61d100230426890df16f8f0440454eeeb9029beab5b47b2490e8a375657f8'
+        c.salt = 'de71bee5d2dc788bec68f6cd691480216c2804bb6aacef8966a14b3a430f9803bb2530d32da366c4d3bd46deb851a494b57de423892bd554e4a8e338f2a06da8'
+      end
+    end
+
+    after :all do
+      ActiveRecord::Base.connection.drop_table('dummys')
+    end
+
+    subject { instance.save! }
+    let(:instance) { dummy_klass.create!(encrypted: value) }
+    let(:value) { :encrypted }
+    let(:dummy_klass) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = 'dummys'
+
+        attribute :encrypted, :encrypted_string
+      end
+    end
+
+    it 'should not update encryption if record did not changed' do
+      # not passing by active record because type#serialize is called twice
+      created_encrypted = ActiveRecord::Base.connection.execute dummy_klass.select(:encrypted).where(id: instance.id).to_sql
+      created_encrypted = created_encrypted.first['encrypted']
+
+      # when read, changed_in_place? is called
+      # https://github.com/rails/rails/blob/v6.0.3.4/activemodel/lib/active_model/attribute.rb#L62-L64
+      instance.encrypted # read
+      instance.save! # save without any changes
+      reload_saved_encrypted = ActiveRecord::Base.connection.execute dummy_klass.select(:encrypted).where(id: instance.id).to_sql
+      reload_saved_encrypted = reload_saved_encrypted.first['encrypted']
+      expect(created_encrypted).to eq(reload_saved_encrypted)
     end
   end
 end

--- a/spec/support/activerecord.rb
+++ b/spec/support/activerecord.rb
@@ -3,3 +3,6 @@
 require 'active_record'
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+
+# uncomment next line to visualize sql statements
+# ActiveRecord::Base.logger = Logger.new(STDOUT) if defined?(ActiveRecord::Base)


### PR DESCRIPTION
Hello again @kamillle 

I finally found a way to trigger `change_in_place?` within a spec. When looking at the stack trace, I found that `changed_in_place?` is called only if the attribute has been read. That's what I was missing. Therefore, I created a spec that simulate its. If you comment the `change_in_place`, you'll see that the test is failing. I must say, that was a tough one 😅


