### PR TITLE
Performance: Memoize Encryptor in ActiveRecordEncryptedString::Type

### DIFF
--- a/gemfiles/5_0_stable.gemfile
+++ b/gemfiles/5_0_stable.gemfile
@@ -6,5 +6,6 @@ source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.0'
 gem 'sqlite3', '~> 1.3.6'
+gem 'concurrent-ruby', '1.3.4', require: false
 
 gemspec path: '../'

--- a/gemfiles/5_1_stable.gemfile
+++ b/gemfiles/5_1_stable.gemfile
@@ -5,5 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.1'
+gem 'concurrent-ruby', '1.3.4', require: false
 
 gemspec path: '../'

--- a/gemfiles/5_2_stable.gemfile
+++ b/gemfiles/5_2_stable.gemfile
@@ -5,5 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.2'
+gem 'concurrent-ruby', '1.3.4', require: false
 
 gemspec path: '../'

--- a/gemfiles/6_0_stable.gemfile
+++ b/gemfiles/6_0_stable.gemfile
@@ -5,5 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.0'
+gem 'concurrent-ruby', '1.3.4', require: false
 
 gemspec path: '../'

--- a/gemfiles/6_1_stable.gemfile
+++ b/gemfiles/6_1_stable.gemfile
@@ -5,5 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.1'
+gem 'concurrent-ruby', '1.3.4', require: false
 
 gemspec path: '../'

--- a/gemfiles/7_0_stable.gemfile
+++ b/gemfiles/7_0_stable.gemfile
@@ -5,5 +5,6 @@
 source 'https://rubygems.org'
 
 gem 'activerecord', '~> 7.0'
+gem 'concurrent-ruby', '1.3.4', require: false
 
 gemspec path: '../'

--- a/lib/active_record_encrypted_string/type.rb
+++ b/lib/active_record_encrypted_string/type.rb
@@ -36,7 +36,8 @@ module ActiveRecordEncryptedString
 
     def encryptor
       # TODO: rotate
-      ActiveSupport::MessageEncryptor.new(secret, cipher: ActiveRecordEncryptedString.configuration.cipher_alg)
+      @encryptor ||=
+        ActiveSupport::MessageEncryptor.new(secret, cipher: ActiveRecordEncryptedString.configuration.cipher_alg)
     end
 
     def secret


### PR DESCRIPTION
Hi, I would like to suggest a small change that has a big impact on performance.

Currently, instantiating the encryptor, especially due to `ActiveSupport::KeyGenerator#generate_key`, is a CPU-intensive operation. This can lead to significant overhead if an encryptor is initialized repeatedly for the same attribute type.

Rails attribute types, like ActiveRecordEncryptedString::Type, are (if I understand it correctly) typically instantiated once per attribute definition (e.g., `attribute :secret_field, :encrypted_string`). This PR leverages this by memoizing the encryptor instance variable (e.g., using `@encryptor ||= ...`).

With the help of the specs I benchmark that change

```ruby
it 'benchmark' do
  Benchmark.bm do |x|
    x.report('encrypt') do
      100.times do |i|
        dummy_klass.create!(plain: plain, encrypted: "test#{i}")
      end
    end
    x.report('decrypt') do
      dummy_klass.pluck(:encrypted)
    end
  end
end

# Without
#              user     system      total        real
# encrypt  6.315960   0.063629   6.379589 (  6.431360)
# decrypt  3.325287   0.023737   3.349024 (  3.364617)
#
# With memorization
#              user     system      total        real
# encrypt  0.126073   0.020950   0.147023 (  0.147913)
# decrypt  0.005078   0.001927   0.007005 (  0.007034)
```

This how I found out

<details><summary>Details</summary>
<p>

```ruby
it 'flamegraph' do
  100.times do |i|
    dummy_klass.create!(plain: plain, encrypted: "test#{i}")
  end
  flamegraph { dummy_klass.pluck(:encrypted) }
end
```
![image](https://github.com/user-attachments/assets/5f68ef96-4c04-4ee2-8a77-66e89559496b)

</p>
</details> 